### PR TITLE
Fix append extension when saving with Return (win 7)

### DIFF
--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
@@ -269,8 +269,10 @@ public:
 	}
 	IFACEMETHODIMP OnSelectionChange(IFileDialog*) override
 	{
-		// This event isn't triggered in an empty folder.
+		// This event may not be triggered in an empty folder (Windows 10+).
 		// Dialog startup calling order: 4. Main window is shown.
+		if (!foundControls())
+			findControls();
 		return S_OK;
 	}
 	IFACEMETHODIMP OnShareViolation(IFileDialog*, IShellItem*, FDE_SHAREVIOLATION_RESPONSE*) override


### PR DESCRIPTION
For some reason, the file name ComboBox isn't present when enumerating windows in OnFolderChange().
Because of that, we can't call onPreFileOk() in keyboard hook procedure.
Fix that by retrying window search in OnSelectionChange() if we didn't find them previously.

Fix #11305